### PR TITLE
Add image download option and a "fancy" stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ automatisch durchführt, wenn die notwendigen Programme vorhanden sind:
 $ ./render.sh https://www.zeit.de/2009/29/Pooh
 ```
 
+Soll ein moderneres Design verwendet werden:
+```
+$ ./render.sh -f https://www.zeit.de/2009/29/Pooh
+```
+
+Sollen die Bilder lokal gespeichert werden:
+```
+$ ./render.sh -d https://www.zeit.de/2009/29/Pooh
+```
+
+Die beiden Optionen lassen sich auch kombinieren.
+
 ## Mindestvoraussetzungen
 
 Theoretisch kann eine Vielzahl von Software zum Einsatz kommen. Getestet
@@ -83,8 +95,6 @@ MacOS getestet.
 * Da die Artikel auf zeit.de nicht völlig homogen formatiert sind, gibt
   es immer wieder Artikel, deren Struktur aktuell nicht perfekt vom
   Stylesheet behandelt werden.
-* Das Design könnte durchaus mit CSS etwas attraktiver gemacht werden
-  und sich besser an verschiedene Bildschirmgrößen anpassen.
 * Für das Lesen eines Artikels unter Windows 3.11 war es zusätzlich
   nötig, von UTF8 nach Latin umzuwandeln. Dies könnte per Option ins
   render.sh integriert werden. Beispiel: `iconv -f UTF-8 -t ISO-8859-1
@@ -96,8 +106,9 @@ MacOS getestet.
 
 Der Name verweist darauf, dass die Umwandlung der Artikel nicht
 automatisiert online erfolgt, sondern ausschließlich auf dem eigenen
-Rechner. Die Artikelfotos werden übrigens nicht gespeichert, sondern
-beim Betrachten eines Artikels von einer Original-Quelle nachgeladen.
+Rechner. Die Artikelfotos werden übrigens standardmäßig nicht gespeichert,
+sondern beim Betrachten eines Artikels von einer Original-Quelle nachgeladen.
+Auf Wunsch kann für den Download der `-d` Parameter verwendet werden.
 
 ## Lizenz
 

--- a/render.sh
+++ b/render.sh
@@ -25,7 +25,7 @@ convert() {
 
 view() {
     local document=$1
-    if has_program xxdg-open; then
+    if has_program xdg-open; then
         xdg-open $document
     elif has_program open; then
         open $document

--- a/render.sh
+++ b/render.sh
@@ -50,12 +50,16 @@ view() {
 
 usage() {
     cat <<EOF
-Usage: $0 URL
+Usage: $0 [-df] URL
 
 Converts articles from zeit.de from XML to simple HTML.
 
 Requires either curl or wget for downloading, xsltproc for conversion and
 xdg-open or open for viewing.
+
+-d : Download images locally
+
+-f : Produce a more fancy version with better styling
 EOF
 }
 

--- a/render.sh
+++ b/render.sh
@@ -19,8 +19,20 @@ get() {
     fi
 }
 
+getImages() {
+    grep -Po '(?<=<img src=")(.+?)(?=")' $1 | while read line
+    do
+        local imageUrl=$(echo "$line" | sed 's/http:\/\/xml/https:\/\/img/g')
+        local imageFile=$(mktemp -p $2 "image.XXXXXXX.jpg")
+        get $imageUrl > $imageFile
+        sed -i "s|$line|file://$imageFile|g" $1
+
+    done
+
+}
+
 convert() {
-    xsltproc zeitoffline.xslt -
+    xsltproc $1 -
 }
 
 view() {
@@ -48,13 +60,35 @@ EOF
 }
 
 make_filename() {
-    echo $(mktemp -u ${TMPDIR:-/tmp}/artikel.XXXXXX).html
+    echo $(mktemp -p $1 "article.XXXXXXX.html")
 }
 
 main() {
-    local filename=$(make_filename)
-    if [ $# -eq 1 ]; then
-        get $1 | convert > $filename
+    local downloadImages=false
+    local xsltFile="zeitoffline.xslt"
+    if [[ $# -gt 0 ]]; then
+        while getopts ":df" opt
+        do
+            case $opt in
+                d)
+                    downloadImages=true
+                    ;;
+                f)
+                    xsltFile="zeitoffline-fancy.xslt"
+                    ;;
+                \?)
+                    echo "Invalid option: -$OPTARG" >&2
+                    usage
+                    exit 1
+            esac
+        done
+        shift $(expr $OPTIND - 1 )
+        local folder=$(mktemp -d)
+        local filename=$(make_filename $folder)
+        get $1 | convert $xsltFile > $filename
+        if [[ $downloadImages = true ]]; then
+            getImages $filename $folder
+        fi
         view $filename
     else
         usage

--- a/zeitoffline-fancy.xslt
+++ b/zeitoffline-fancy.xslt
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html" doctype-system="about:legacy-compat"/>
+    <xsl:template match="/">
+        <html>
+            <head>
+                <title>
+                    <xsl:value-of select="article/body/title"/>
+                </title>
+                <meta content="width=device-width, initial-scale=1" name="viewport"/>
+            </head>
+            <style type="text/css">
+                body {
+                display: flex;
+                justify-content: center;
+                font-family: "Palatino Linotype", "Book Antiqua", Palatino, serif
+                }
+                .container {
+                margin: 10px;
+                }
+                @media (min-width: 900px) {
+                .container {
+                max-width: 50vw;
+                }
+                }
+                h1, h2, h3, .sans {
+                font-family: Roboto, Helvetica, Arial, sans-serif;
+                }
+                img {
+                padding-bottom: 5px;
+                max-width: 50vw;
+                width: 100%;
+                }
+                .meta {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: space-between;
+                font-size: 10pt;
+                color: grey;
+                }
+                .meta * {
+                margin: 0 5px;
+                }
+                .meta:first-child {
+                margin-left: 0;
+                }
+                .meta:last-child {
+                margin-right: 0;
+                }
+                span.bildunterschrift { font-size: small; }
+                span.copyright { font-size:x-small; }
+            </style>
+            <body>
+                <div class="container">
+                    <h1>
+                        <xsl:value-of select="article/body/title"/>
+                    </h1>
+                    <div class="sans meta">
+                        <i>von:
+                            <xsl:value-of select="article/head/author/display_name"/>
+                        </i>
+                        <span>veröffentlicht am:
+                            <xsl:value-of select="substring(article/head/attribute[@name='date_first_released'],1,10)"/>
+                        </span>
+                        <xsl:if test="count(article/head/rankedTags/tag[@type='location']) > 0">
+                            <span>
+                                Ort:
+                                <xsl:for-each select="article/head/rankedTags/tag[@type='location']">
+                                    <xsl:copy-of select="."/><xsl:if test="position() &lt; last()">,</xsl:if>
+                                </xsl:for-each>
+                            </span>
+                        </xsl:if>
+                        <xsl:if test="count(article/head/rankedTags/tag[@type='keyword']) > 0">
+                            <span>
+                                Schlüsselwörter:
+                                <xsl:for-each select="article/head/rankedTags/tag[@type='keyword']">
+                                    <xsl:copy-of select="."/>
+                                    <xsl:if test="position() &lt; last()">,</xsl:if>
+                                </xsl:for-each>
+                            </span>
+                        </xsl:if>
+                    </div>
+                    <xsl:apply-templates/>
+                </div>
+            </body>
+        </html>
+    </xsl:template>
+    <xsl:template match="attribute"/>
+    <xsl:template match="rankedTags"/>
+    <xsl:template match="author"/>
+    <xsl:template match="subtitle">
+        <p class="sans">
+            <i>
+                <xsl:copy-of select="."/>
+            </i>
+        </p>
+    </xsl:template>
+    <xsl:template match="byline"/>
+    <xsl:template match="caption"/>
+    <xsl:template match="image-credits"/>
+    <xsl:template match="bu"/>
+    <xsl:template match="teaser"/>
+    <xsl:template match="title"/>
+    <xsl:template match="copyright"/>
+    <xsl:template match="division/image">
+        <p>
+            <img>
+                <xsl:attribute name="src"><xsl:value-of select="./@base-id"/>wide__820x461__desktop</xsl:attribute>
+                <xsl:attribute name="alt">
+                    <xsl:value-of select="./@alt_local"/>
+                </xsl:attribute>
+            </img>
+            <span class="bildunterschrift sans">
+                <xsl:value-of select="./@caption_local"/>
+            </span>
+            <xsl:if test="copyright/text()">
+                <br/>
+                <span class="copyright sans">©
+                    <xsl:value-of select="copyright"/>
+                </span>
+            </xsl:if>
+        </p>
+    </xsl:template>
+    <xsl:template match="intertitle">
+        <h3>
+            <xsl:copy-of select="."/>
+        </h3>
+    </xsl:template>
+    <xsl:template match="supertitle">
+        <h2>
+            <xsl:copy-of select="."/>
+        </h2>
+    </xsl:template>
+    <xsl:template match="p">
+        <p>
+            <xsl:copy-of select="."/>
+        </p>
+    </xsl:template>
+</xsl:stylesheet>

--- a/zeitoffline-fancy.xslt
+++ b/zeitoffline-fancy.xslt
@@ -49,6 +49,9 @@
                 }
                 span.bildunterschrift { font-size: small; }
                 span.copyright { font-size:x-small; }
+                p {
+                text-align: justify;
+                }
             </style>
             <body>
                 <div class="container">
@@ -103,23 +106,25 @@
     <xsl:template match="title"/>
     <xsl:template match="copyright"/>
     <xsl:template match="division/image">
-        <p>
-            <img>
-                <xsl:attribute name="src"><xsl:value-of select="./@base-id"/>wide__820x461__desktop</xsl:attribute>
-                <xsl:attribute name="alt">
-                    <xsl:value-of select="./@alt_local"/>
-                </xsl:attribute>
-            </img>
-            <span class="bildunterschrift sans">
-                <xsl:value-of select="./@caption_local"/>
-            </span>
-            <xsl:if test="copyright/text()">
-                <br/>
-                <span class="copyright sans">©
-                    <xsl:value-of select="copyright"/>
+        <xsl:if test="./@base-id">
+            <p>
+                <img>
+                    <xsl:attribute name="src"><xsl:value-of select="./@base-id"/>wide__820x461__desktop</xsl:attribute>
+                    <xsl:attribute name="alt">
+                        <xsl:value-of select="./@alt_local"/>
+                    </xsl:attribute>
+                </img>
+                <span class="bildunterschrift sans">
+                    <xsl:value-of select="./@caption_local"/>
                 </span>
-            </xsl:if>
-        </p>
+                <xsl:if test="copyright/text()">
+                    <br/>
+                    <span class="copyright sans">©
+                        <xsl:value-of select="copyright"/>
+                    </span>
+                </xsl:if>
+            </p>
+        </xsl:if>
     </xsl:template>
     <xsl:template match="intertitle">
         <h3>

--- a/zeitoffline.xslt
+++ b/zeitoffline.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foo="http://www.foo.org/" xmlns:bar="http://www.bar.org">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:template match="/">
   <html>
     <head><title><xsl:value-of select="article/body/title"/></title></head>


### PR DESCRIPTION
Hi,

ich habe mit mal erlaubt, meine private Style-Anpassung und den Image-Download in den bestehenden Code zu integrieren und den Pull-Request hier zu erstellen.

**Änderungen**:

- Typo bei `xdg-open` behoben
- Für jeden Artikel wird jetzt ein eigener Ordner erstellt
- Unsafe Nutzung von `mktemp` entfernt
- Überflüssige XML-Namespaces entfernt

**Neuerungen**:

 - `-d` Option: Lädt die Bilder ebenfalls lokal herunter
 - `-f` Option: Verwendet ein minimalistisches, aber eben (subjektiv) etwas hübscheres Stylesheet mit Flexbox, Blocksatz und generell etwas mehr CSS


Feedback arbeite ich gerne auch noch ein, wenn es nicht zu großes wird, aber vermutlich erst nach Ostern.

Viele Grüße
- Ole
