### PR TITLE
fix typo in render.sh

### DIFF
--- a/render.sh
+++ b/render.sh
@@ -25,7 +25,7 @@ convert() {
 
 view() {
     local document=$1
-    if has_program xxdg-open; then
+    if has_program xdg-open; then
         xdg-open $document
     elif has_program open; then
         open $document


### PR DESCRIPTION
Wenn nur xdg-open installiert ist, schlug render.sh fehl, da es auf xxdg-open prüfte. Jetzt sollte es gehen.